### PR TITLE
Fix: Allow filename extensions to be three numeric digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build + Test](https://github.com/behringer24/isokinexp/actions/workflows/go.yml/badge.svg)](https://github.com/behringer24/isokinexp/actions/workflows/go.yml)
 [![Release build](https://github.com/behringer24/isokinexp/actions/workflows/release.yml/badge.svg)](https://github.com/behringer24/isokinexp/actions/workflows/release.yml)
 
-isokinexp is a command line tool to import/export/sort files from isokinetic measuring devices from Ferstl like the Isomed 2000.
+isokinexp is a command line tool to import/export/sort files from isokinetic measuring devices from Ferstl like the Isomed 2000. Files are copied or moved into a file and filename structure /<name of person>/<name of person><Y-m-d>.txt
 
 # Basic usage
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,3 @@
-/*
-Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-*/
 package cmd
 
 import (
@@ -24,7 +21,7 @@ var (
 	rootCmd = &cobra.Command{
 		Use:     "isokinexp",
 		Short:   "Exporter / renamer for isokinetic device files",
-		Version: "0.0.3",
+		Version: "0.0.4",
 		Long:    `isokinexp is a command to import export files from isokinetic measureing devices.`,
 		// Uncomment the following line if your bare application
 		// has an action associated with it:
@@ -73,11 +70,12 @@ func copy() {
 	// Define regular expression patterns to match the filename and date information
 	datePattern := regexp.MustCompile(`Date of Test:\s*(\d{2})\.(\d{2})\.(\d{4})`)
 	namePattern := regexp.MustCompile(`Name of Person:\s*(\w+)`)
+	filePattern := regexp.MustCompile(`\.\d{3}`)
 
 	// Iterate over each file in the source directory
 	for _, file := range files {
-		// Check if the file is a .txt file
-		if !file.IsDir() && filepath.Ext(file.Name()) == ".585" {
+		// Check if the file is not a directory and has a 3 digit feliname ext
+		if !file.IsDir() && filePattern.Match([]byte(filepath.Ext(file.Name()))) {
 			// Read the contents of the file
 			content, err := ioutil.ReadFile(filepath.Join(srcPath, file.Name()))
 			if err != nil {


### PR DESCRIPTION
Fix: Allow filename extensions to be three numeric digits instead of hardcoded .585