### PR TITLE
Fix: zero length files when time string contains :

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ var (
 	rootCmd = &cobra.Command{
 		Use:     "isokinexp",
 		Short:   "Exporter / renamer for isokinetic device files",
-		Version: "0.2.0",
+		Version: "0.2.1",
 		Long:    `isokinexp is a command to import export files from isokinetic measureing devices.`,
 		// Uncomment the following line if your bare application
 		// has an action associated with it:
@@ -101,7 +101,7 @@ func copy() {
 					name = matches[1]
 				}
 				if matches := timePattern.FindStringSubmatch(line); len(matches) > 1 {
-					time = matches[1]
+					time = strings.Replace(matches[1], ":", "-", 1)
 				}
 				if name != "" && date != "" {
 					break


### PR DESCRIPTION
Fix: Bugfix for 0-length files. ":" from time string is not allowed on Windows machines. replacing with "-" for new filenames